### PR TITLE
Integrated vscode-dotnet-runtime

### DIFF
--- a/src/AvaloniaLSP/AvaloniaLanguageServer/AvaloniaLanguageServer.csproj
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/AvaloniaLanguageServer.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
         <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.19.7" />
         <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />
-        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+        <PackageReference Include="serilog" Version="3.0.1" />
         
     </ItemGroup>
 

--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Program.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Program.cs
@@ -19,8 +19,7 @@ public class Program
         options
             .WithInput(Console.OpenStandardInput())
             .WithOutput(Console.OpenStandardOutput())
-            .ConfigureLogging(
-                b => b.AddSerilog(Log.Logger)
+            .ConfigureLogging(p=>p
                 .AddLanguageProtocolLogging()
                 .SetMinimumLevel(LogLevel.Trace))
             .WithHandler<HoverHandler>()
@@ -41,7 +40,6 @@ public class Program
     static void InitializeLogging()
     {
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.File("/Users/prashantvc/avalonia-logs/server.log", rollingInterval: RollingInterval.Hour)
             .Enrich.FromLogContext()
             .MinimumLevel.Verbose()
             .CreateLogger();

--- a/src/vscode-avalonia/src/client.ts
+++ b/src/vscode-avalonia/src/client.ts
@@ -1,12 +1,11 @@
 import * as vscode from "vscode";
-import * as path from "path";
 import * as lsp from "vscode-languageclient/node";
+import { getDotnetRuntimePath, getLanguageServerPath as getAvaloniaServerPath } from "./runtimeManager";
 
-export async function createLanguageService(context: vscode.ExtensionContext): Promise<lsp.LanguageClient> {
+export async function createLanguageService(): Promise<lsp.LanguageClient> {
 	logger.appendLine("Creating language service");
-	const serverPath = getLSPPath(context);
 
-	const serverOptions = getServerStartupOptions(serverPath);
+	const serverOptions = await getServerStartupOptions();
 	let outputChannel = logger;
 
 	const clientOptions: lsp.LanguageClientOptions = {
@@ -35,8 +34,10 @@ export async function createLanguageService(context: vscode.ExtensionContext): P
 	return client;
 }
 
-function getServerStartupOptions(serverPath: string): lsp.ServerOptions {
-	const dotnetCommandPath = "/usr/local/share/dotnet/dotnet";
+async function getServerStartupOptions(): Promise<lsp.ServerOptions> {
+	const dotnetCommandPath = await getDotnetRuntimePath();
+	const serverPath = getAvaloniaServerPath();
+
 	const executable = {
 		command: dotnetCommandPath,
 		args: [serverPath],
@@ -49,11 +50,6 @@ function getServerStartupOptions(serverPath: string): lsp.ServerOptions {
 		run: executable,
 		debug: executable,
 	};
-}
-
-function getLSPPath(context: vscode.ExtensionContext) {
-	const serverPath = context.asAbsolutePath("avaloniaServer/AvaloniaLanguageServer.dll");
-	return path.resolve(serverPath);
 }
 
 export const avaloniaFileExtension = "axaml";

--- a/src/vscode-avalonia/src/extension.ts
+++ b/src/vscode-avalonia/src/extension.ts
@@ -14,7 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(disposable);
 
-	languageClient = await createLanguageService(context);
+	languageClient = await createLanguageService();
 
 	try {
 		logger.appendLine("Starting Avalonia Language Server...");

--- a/src/vscode-avalonia/src/runtimeManager.ts
+++ b/src/vscode-avalonia/src/runtimeManager.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+const extensionId = "AvaloniaTeam.vscode-avalonia";
+const dotnetRuntimeVersion = "7.0";
+
+export async function getDotnetRuntimePath(): Promise<string> {
+	await vscode.commands.executeCommand("dotnet.showAcquisitionLog");
+
+	const commandRes = await vscode.commands.executeCommand<{ dotnetPath: string }>("dotnet.acquire", {
+		version: dotnetRuntimeVersion,
+		requestingExtensionId: extensionId,
+	});
+	const dotnetPath = commandRes!.dotnetPath;
+	if (!dotnetPath) {
+		throw new Error("Could not resolve the dotnet path!");
+	}
+	const serverLocation = getLanguageServerPath();
+
+	// This will install any missing dependencies
+	await vscode.commands.executeCommand("dotnet.ensureDotnetDependencies", {
+		command: dotnetPath,
+		arguments: [serverLocation],
+	});
+
+	return dotnetPath;
+}
+
+export function getLanguageServerPath() {
+	const avaloniaExtn = vscode.extensions.getExtension(extensionId);
+	if (!avaloniaExtn) {
+		throw new Error("Could not find sample extension.");
+	}
+	const serverLocation = path.join(avaloniaExtn.extensionPath, "avaloniaServer", "AvaloniaLanguageServer.dll");
+	return serverLocation;
+}


### PR DESCRIPTION
This PR integrates `ms-dotnettools.vscode-dotnet-runtime` extension to manage `dotnet` dependency for the extension

The extension does not need to depend n the system wide dotnet installation. 

fixes #1 
