### PR TITLE
fix: typo in command title to create previewer assets

### DIFF
--- a/src/vscode-avalonia/package.json
+++ b/src/vscode-avalonia/package.json
@@ -74,7 +74,7 @@
     "commands": [
       {
         "command": "avalonia.createPreviewerAssets",
-        "title": "Create previwer assets",
+        "title": "Create previewer assets",
         "category": "Avalonia"
       },
       {


### PR DESCRIPTION
Fix typo in command title for creating previewer assets. 
Was "Create previwer assets", now "Create previewer assets"

