### PR TITLE
Use dotnet.findpath to resolve the existing global installed version

### DIFF
--- a/src/vscode-avalonia/src/runtimeManager.ts
+++ b/src/vscode-avalonia/src/runtimeManager.ts
@@ -13,18 +13,22 @@ const dotnetRuntimeVersion = "8.0";
  * @throws An error if the .NET runtime path could not be resolved.
  */
 export async function getDotnetRuntimePath(): Promise<string> {
-	await vscode.commands.executeCommand("dotnet.showAcquisitionLog");
-
-	const commandRes = await vscode.commands.executeCommand<{ dotnetPath: string }>("dotnet.acquire", {
-		version: dotnetRuntimeVersion,
-		requestingExtensionId: AppConstants.extensionId,
+	const path = await vscode.commands.executeCommand<string>("dotnet.findPath", {
+		
+		acquireContext: {
+			version: dotnetRuntimeVersion,
+			requestingExtensionId: AppConstants.extensionId,
+			mode: 'runtime',
+			installType: 'global',
+			architecture: process.arch
+		},
+		versionSpecRequirement: 'greater_than_or_equal'
 	});
-	const dotnetPath = commandRes!.dotnetPath;
-	if (!dotnetPath) {
+	if (!path) {
 		throw new Error("Could not resolve the dotnet path!");
 	}
 
-	return dotnetPath;
+	return path;
 }
 
 /**


### PR DESCRIPTION
This fixes an issue where on linux (maybe elsewhere also) autocompletion/preview asks you to build the project, but clicking build the project, or building the project doesn't help.

This code was using `dotnet.acquire` to get the runtime version of dotnet to use. This is resolving an old version of dotnet runtime (8.0.10).

I suspect this wasn't working because it needs the sdk to do the build not just the runtime. However using the alternative `dotnet.acquireGlobalSDK` would fail on Ubuntu 22.04 with a message that said dotnet sdk 8.0.403 isn't officially supported on ubuntu 22.04 (this is despite this being the exact version I already have installed)

People have pointed out that you can work around this by specifying the global dotnet to use in your vscode settings.json as follows:

```
    "dotnetAcquisitionExtension.existingDotnetPath": [
        {"extensionId": "AvaloniaTeam.vscode-avalonia", "path": "/usr/bin/dotnet"}
    ],
```

This merge request formalises this by making the extension find and use the global installed dotnet using the new `dotnet.findpath` the details of which you can find here: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/commands.md

It does mean that people need to install dotnet themselves, as the extension will no longer install one for itself to use. However if you developing an avalonia app you have to already have dotnet installed so I think this is OK.

This may resolve #123, #117, #88

To get things fully working again I also had to update the versions of Microsoft.Build and Microsoft.Build.Utilities.Core in the upstream SolutionParser, I've also raised a pull request against it to fix that here: https://github.com/prashantvc/SolutionParser/pull/4