### PR TITLE
Use IDotnetAcquireResult for dotnet.findPath result

### DIFF
--- a/src/vscode-avalonia/src/runtimeManager.ts
+++ b/src/vscode-avalonia/src/runtimeManager.ts
@@ -7,13 +7,17 @@ import { AppConstants } from "./util/Utilities";
  */
 const dotnetRuntimeVersion = "8.0";
 
+interface IDotnetAcquireResult {
+    dotnetPath: string;
+}
+
 /**
  * Gets the path to the .NET runtime.
  * @returns A promise that resolves to the path to the .NET runtime.
  * @throws An error if the .NET runtime path could not be resolved.
  */
 export async function getDotnetRuntimePath(): Promise<string> {
-	const path = await vscode.commands.executeCommand<string>("dotnet.findPath", {
+	const path = await vscode.commands.executeCommand<IDotnetAcquireResult>("dotnet.findPath", {
 		
 		acquireContext: {
 			version: dotnetRuntimeVersion,
@@ -28,7 +32,7 @@ export async function getDotnetRuntimePath(): Promise<string> {
 		throw new Error("Could not resolve the dotnet path!");
 	}
 
-	return path;
+	return path.dotnetPath;
 }
 
 /**


### PR DESCRIPTION
See breaking change in vscode-dotnet-runtime:
https://github.com/dotnet/vscode-dotnet-runtime/blob/814208c72c9ecbfdc0d979c486eddfd3915e0b3e/vscode-dotnet-runtime-extension/CHANGELOG.md?plain=1#L22

The `findPath` command now returns a `IDotnetAcquireResult` object instead of a string. The string containing the actual path is in the `dotnetPath` property. With the current code, the result was an "unsupported server configuration" error when starting the LSP client. This PR fixes the error.