### PR TITLE
Update SolutionParser (uses MSBuild Locator)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/AvaloniaUI/AvaloniaVS.git
 [submodule "src/SolutionParser"]
 	path = src/SolutionParser
-	url = https://github.com/prashantvc/SolutionParser/
+	url = https://github.com/AvaloniaUI/SolutionParser/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome to Avalonia Extension for VS Code! We appreciate your interest in contri
 
 ## System Requirements
 
-1. dotnet 8.0, you can download it from [here](https://dotnet.microsoft.com/en-us/download)
+1. dotnet 9.0, you can download it from [here](https://dotnet.microsoft.com/en-us/download)
 2. NodeJS, npm 
    You can get NodeJS and npm using NVM (Node Version Manager) by running the following command:
    

--- a/src/vscode-avalonia/README.md
+++ b/src/vscode-avalonia/README.md
@@ -6,7 +6,7 @@ The Avalonia for Visual Studio Code Extension contains support for Avalonia XAML
 
 Follow the [contribution guide](CONTRIBUTING.md) if you want to help us build the extension
 
-> **NOTE:** Requires .NET Core 8.0
+> **NOTE:** Requires .NET 9.0
 
 ## Getting Started
 

--- a/src/vscode-avalonia/src/runtimeManager.ts
+++ b/src/vscode-avalonia/src/runtimeManager.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { AppConstants } from "./util/Utilities";
+import { AppConstants, logger } from "./util/Utilities";
 
 /**
  * The version of the .NET runtime to acquire.
  */
-const dotnetRuntimeVersion = "8.0";
+const dotnetRuntimeVersion = "9.0";
 
 interface IDotnetAcquireResult {
     dotnetPath: string;
@@ -18,7 +18,6 @@ interface IDotnetAcquireResult {
  */
 export async function getDotnetRuntimePath(): Promise<string> {
 	const path = await vscode.commands.executeCommand<IDotnetAcquireResult>("dotnet.findPath", {
-		
 		acquireContext: {
 			version: dotnetRuntimeVersion,
 			requestingExtensionId: AppConstants.extensionId,
@@ -28,8 +27,11 @@ export async function getDotnetRuntimePath(): Promise<string> {
 		},
 		versionSpecRequirement: 'greater_than_or_equal'
 	});
+
 	if (!path) {
-		throw new Error("Could not resolve the dotnet path!");
+		const message = `.NET ${dotnetRuntimeVersion} was not found. Please make sure it's installed globally.`;
+		logger.error(message);
+		throw new Error(message);
 	}
 
 	return path.dotnetPath;


### PR DESCRIPTION
This PR updates the SolutionParser submodule, which now uses MSBuild Locator to avoid various errors due to MSBuild version mismatches between the .NET SDK and SolutionParser. See https://github.com/AvaloniaUI/SolutionParser/pull/6 for details.

As part of this change, **AvaloniaVSCode now requires .NET 9.0** to run properly.

This should fix the following issues:
 - Fixes #40
 - Fixes #88
 - Fixes #137
 - Fixes #142
 - Fixes #145