### PR TITLE
Remove unnecessary warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Avalonia for Visual Studio Code
 
-## Requires Avalonia v11.0.2 or lower
-
-The extension require Avalonia nuget package v11.0.2 or lower. The latest version **v11.0.5 of Avalonia package will break the previewer**
-
-<hr/>
-
-Avalonia is a cross-platform XAML-based UI framework providing a flexible styling system and supporting a wide range of Operating Systems such as Windows via .NET Framework and .NET Core, Linux via Xorg and macOS.
+[Avalonia](https://github.com/AvaloniaUI/Avalonia/) is a cross-platform XAML-based UI framework providing a flexible styling system and supporting a wide range of Operating Systems such as Windows via .NET Framework and .NET Core, Linux via Xorg and macOS.
 
 The Avalonia for Visual Studio Code Extension contains support for Avalonia XAML autocomplete and previewer.
 


### PR DESCRIPTION
AvaloniaVSCode works fine with the latest Avalonia versions: this PR removes the warning that it's broken with 11.0.5 and later.

Fixes #136