### PR TITLE
allow worskspace to parse fsharp projects

### DIFF
--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Models/ProjectInfo.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Models/ProjectInfo.cs
@@ -20,7 +20,7 @@ public class ProjectInfo
             {
                 var directory = new DirectoryInfo(current!);
                 files = directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly);
-
+                files = files.Concat(directory.GetFiles("*.fsproj",SearchOption.TopDirectoryOnly)).ToArray();
                 if (files.Length != 0)
                     break;
 


### PR DESCRIPTION
This allows the extension to also load fsharp projects. It should fix this issue: #150 

