### PR TITLE
AvaloniaLanguageServer.csproj:Update to .NET 9.0 to fix errors

### DIFF
--- a/src/AvaloniaLSP/AvaloniaLanguageServer/AvaloniaLanguageServer.csproj
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/AvaloniaLanguageServer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
If use .NET 9.0 to run Avalonia for vscode, will be errors: 

```You must install or update .NET to run this application.

App: /home/gamma/.vscode-oss/extensions/avaloniateam.vscode-avalonia-0.0.26-universal/solutionParserTool/SolutionParser.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
.NET location: /home/gamma/.dotnet/

The following frameworks were found:
  9.0.3 at [/home/gamma/.dotnet/shared/Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=linux-x64&os=aosc.12.1.0```