### PR TITLE
make `*.sln.json` consistent between `solutionParser.ts` and `Workspace.cs`

### DIFF
--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/CompletionHandler.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/CompletionHandler.cs
@@ -1,5 +1,6 @@
 using Avalonia.Ide.CompletionEngine;
 using AvaloniaLanguageServer.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace AvaloniaLanguageServer.Handlers;
 
@@ -84,16 +85,17 @@ public class CompletionHandler : CompletionHandlerBase
 
         if (_workspace.ProjectInfo.IsAssemblyExist && _workspace.CompletionMetadata == null)
         {
-            await _workspace.InitializeAsync(uri);
+            await _workspace.InitializeAsync(uri, _getServer()?.Client.ClientSettings.RootPath);
         }
 
         return _workspace.CompletionMetadata;
     }
 
-    public CompletionHandler(Workspace workspace, DocumentSelector documentSelector)
+    public CompletionHandler(Workspace workspace, DocumentSelector documentSelector, Func<ILanguageServer?> getServer)
     {
         _workspace = workspace;
         _documentSelector = documentSelector;
+        _getServer = getServer;
 
         _completionEngine = new CompletionEngine();
     }
@@ -122,6 +124,7 @@ public class CompletionHandler : CompletionHandlerBase
 
     readonly Workspace _workspace;
     readonly DocumentSelector _documentSelector;
+    readonly Func<ILanguageServer?> _getServer;
 
     readonly CompletionEngine _completionEngine;
 

--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/HoverHandler.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/HoverHandler.cs
@@ -21,7 +21,7 @@ public sealed class HoverHandler : HoverHandlerBase
     {
         if (_workspace.ProjectInfo == null)
         {
-            await _workspace.InitializeAsync(request.TextDocument.Uri);
+            await _workspace.InitializeAsync(request.TextDocument.Uri, _getServer()?.Client.ClientSettings.RootPath);
         }
 
         var hover = new Hover
@@ -35,13 +35,13 @@ public sealed class HoverHandler : HoverHandlerBase
         };
 
         var server = _getServer();
-        _logger.LogInformation("*** Server: {Server}", server.Client.ClientSettings.RootPath);
+        _logger.LogInformation("*** Server: {Server}", server?.Client.ClientSettings.RootPath);
 
         return hover;
     }
 
     public HoverHandler(Workspace workspace, DocumentSelector documentSelector, ILogger<HoverHandler> logger
-    , Func<ILanguageServer> getServer)
+    , Func<ILanguageServer?> getServer)
     {
         _workspace = workspace;
         _documentSelector = documentSelector;
@@ -49,7 +49,7 @@ public sealed class HoverHandler : HoverHandlerBase
         _getServer = getServer;
     }
 
-    Func<ILanguageServer> _getServer;
+    Func<ILanguageServer?> _getServer;
 
     readonly DocumentSelector _documentSelector;
     readonly ILogger<HoverHandler> _logger;

--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/TextDocumentSyncHandler.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Handlers/TextDocumentSyncHandler.cs
@@ -12,7 +12,8 @@ public class TextDocumentSyncHandler: TextDocumentSyncHandlerBase
     private readonly ILanguageServerConfiguration _configuration;
     private readonly DocumentSelector _documentSelector;
     private readonly Workspace _workspace;
-    
+    private readonly Func<ILanguageServer?> _getServer;
+
 
     public override async Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken cancellationToken)
     {
@@ -24,7 +25,7 @@ public class TextDocumentSyncHandler: TextDocumentSyncHandlerBase
         conf.GetSection("Avalonia").Bind(options);
 
         string text = request.TextDocument.Text;
-        await _workspace.InitializeAsync(uri);
+        await _workspace.InitializeAsync(uri, _getServer()?.Client.ClientSettings.RootPath);
         _workspace.BufferService.Add(uri, text);
         
         _logger.LogInformation("** DidOpenText: {Uri}", uri);
@@ -90,12 +91,14 @@ public class TextDocumentSyncHandler: TextDocumentSyncHandlerBase
         ILogger<TextDocumentSyncHandler> logger, 
         ILanguageServerConfiguration configuration,
         DocumentSelector documentSelector,
-        Workspace workspace)
+        Workspace workspace,
+        Func<ILanguageServer?> getServer)
     {
         _logger = logger;
         _configuration = configuration;
         _documentSelector = documentSelector;
         _workspace = workspace;
+        _getServer = getServer;
     }
     
     public class ServerOptions

--- a/src/AvaloniaLSP/AvaloniaLanguageServer/Program.cs
+++ b/src/AvaloniaLSP/AvaloniaLanguageServer/Program.cs
@@ -6,7 +6,7 @@ namespace AvaloniaLanguageServer;
 
 public class Program
 {
-    static ILanguageServer server;
+    static ILanguageServer? server;
     public static async Task Main(string[] args)
     {
         InitializeLogging();
@@ -28,7 +28,12 @@ public class Program
             )
             .WithHandler<CompletionHandler>()
             .WithHandler<TextDocumentSyncHandler>()
-            .WithServices(ConfigureServices);
+            .WithServices(ConfigureServices)
+            .OnInitialize((init_server, request, token) =>
+            {
+                server = init_server;
+                return Task.CompletedTask;
+            });
     }
 
     static void ConfigureServices(IServiceCollection services)
@@ -41,7 +46,7 @@ public class Program
         services.AddSingleton(GetServer);
     }
 
-    static ILanguageServer GetServer() => server;
+    static ILanguageServer? GetServer() => server;
 
     static void InitializeLogging()
     {

--- a/src/vscode-avalonia/src/services/solutionParser.ts
+++ b/src/vscode-avalonia/src/services/solutionParser.ts
@@ -51,7 +51,7 @@ export async function getSolutionDataFile() {
 		return;
 	}
 
-	return path.join(os.tmpdir(), path.basename(slnFile) + ".json");
+	return path.join(os.tmpdir(), `${path.basename(slnFile)}.json`);
 }
 
 /**


### PR DESCRIPTION
`solutionParser.ts` looks for `${workspace}/**.sln`, and fallsback to workspaceFolder
`Workspace.cs` looks for `/**.sln` or `C:\**.sln` on windows, and fallsback to projectFolder(`.csproj`)

break case: `solutionParser.ts` uses fallback, but `Workspace.cs` doesn't:
`solutionParser.ts` writes to `${basename(workspaceFolder)}.json`
`Workspace.cs` expects `solutionName.sln.json` (`solutionName.sln` found since it looks further up compared to `solutionParser.ts`)
file not found

___

```ts
const filePattern = "**/*.sln";
const files = await vscode.workspace.findFiles(filePattern);

if (files.length > 0) {
	return files[0].fsPath;
}

return vscode.workspace.workspaceFolders?.[0].uri.fsPath;
```
is replicated with
```c#
    string? SolutionName(string RootPath)
    {
        var slnFiles = Directory.EnumerateFiles(RootPath, "*.sln", SearchOption.AllDirectories);
        foreach (string slnFile in slnFiles)
        {
            return Path.GetFileName(slnFile);
        }
        return null;
    }
    
    Metadata? BuildCompletionMetadata(string? RootPath)
    {
        if (RootPath == null)
            return null;

        var slnFile = SolutionName(RootPath) ?? Path.GetFileNameWithoutExtension(RootPath);
        ...
    }
```
the only caveat is that `Directory.EnumerateFiles` doesn't respect `.gitignore`, while vscode probably does

___

`TextDocumentSyncHandler.cs` `Handle()` is reached before `server = await LanguageServer.From(ConfigureOptions);` is set
`_getServer()` returns `null` at that point, this makes `server` available earlier:
```c#
            .OnInitialize((init_server, request, token) =>
            {
                server = init_server;
```